### PR TITLE
CLI "auto" syntax support, tidying

### DIFF
--- a/bin/sast-parse
+++ b/bin/sast-parse
@@ -16,7 +16,7 @@ const formatters = {
     return JSON.stringify(tree, null, ' '.repeat(indent))
   },
   'string': stringify,
-  'tree': tree => inspect.noColor(tree),
+  'tree': (tree, {color}) => color ? inspect(tree) : inspect.noColor(tree),
   'yaml': (tree, {pretty, indent, flowLevel}) => {
     const opts = pretty
       ? {indent: 2}
@@ -49,6 +49,11 @@ const yargs = require('yargs')
     choices: syntaxes,
     default: 'auto',
     type: 'string',
+  })
+  .option('color', {
+    desc: `Enable colored output for --format=tree`,
+    type: 'boolean',
+    alias: 'c',
   })
   .option('format', {
     desc: `Specify the output format`,

--- a/bin/sast-parse
+++ b/bin/sast-parse
@@ -97,6 +97,9 @@ fse.readFile(input, 'utf8')
       // console.warn('[x] trimming the input')
       source = source.trim()
     }
+    if (options.syntax === 'auto') {
+      options.syntax = input.split('.').pop()
+    }
     return parse(source, options)
   })
   .catch(error => {

--- a/src/mapify.js
+++ b/src/mapify.js
@@ -1,4 +1,3 @@
-const inspect = require('unist-util-inspect')
 const invariant = require('invariant')
 const is = require('unist-util-is')
 const split = require('./split')

--- a/src/parse.js
+++ b/src/parse.js
@@ -21,17 +21,18 @@ const parse = (source, options) => {
 }
 
 const degonzify = src => {
+  const {type, start, end, content} = src
   const node = {
-    type: src.type,
+    type,
     position: {
-      start: src.start,
-      end: src.end,
+      start,
+      end
     }
   }
-  if (Array.isArray(src.content)) {
-    node.children = src.content.map(degonzify)
+  if (Array.isArray(content)) {
+    node.children = content.map(degonzify)
   } else {
-    node.value = src.content
+    node.value = content
   }
   return node
 }


### PR DESCRIPTION
* 🚀 Fixes/adds support for the `auto` syntax in the `sast-parse` CLI, inferring syntax from the filename extension.
* 💅 Tidies up some stuff