### PR TITLE
Update yargs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,44 @@
 {
-  "name": "sast",
-  "version": "0.8.1",
-  "description": "Parse CSS, Sass, and SCSS into Unist syntax trees",
-  "main": "index.js",
-  "bin": {
-    "sast-parse": "bin/sast-parse",
-    "sast-data": "bin/sast-data"
-  },
-  "scripts": {
-    "test": "ava --verbose test/*.js"
-  },
-  "keywords": [
-    "css",
-    "sass",
-    "sast",
-    "scss",
-    "syntax-tree",
-    "unist"
-  ],
-  "repository": "github:shawnbot/sast",
-  "author": "Shawn Allen <shawn.allen@github.com>",
-  "license": "Unlicense",
-  "dependencies": {
-    "fs-extra": "^4.0.2",
-    "gonzales-pe": "^4.2.2",
-    "invariant": "^2.2.2",
-    "js-yaml": "^3.13.1",
-    "minimatch": "^3.0.4",
-    "unist-util-find": "^1.0.1",
-    "unist-util-inspect": "^4.1.1",
-    "unist-util-is": "^2.1.1",
-    "unist-util-map": "^1.0.3",
-    "unist-util-remove": "^1.0.0",
-    "unist-util-remove-position": "^1.1.1",
-    "unist-util-select": "^1.5.0",
-    "unist-util-visit": "^1.1.3",
-    "unist-util-visit-parents": "^1.1.1",
-    "yargs": "^9.0.1"
-  },
-  "devDependencies": {
-    "ava": "^1.4.1"
-  }
+	"name": "sast",
+	"version": "0.8.1",
+	"description": "Parse CSS, Sass, and SCSS into Unist syntax trees",
+	"main": "index.js",
+	"bin": {
+		"sast-parse": "bin/sast-parse",
+		"sast-data": "bin/sast-data"
+	},
+	"scripts": {
+		"test": "ava --verbose test/*.js"
+	},
+	"keywords": [
+		"css",
+		"sass",
+		"sast",
+		"scss",
+		"syntax-tree",
+		"unist"
+	],
+	"repository": "github:shawnbot/sast",
+	"author": "Shawn Allen <shawn.allen@github.com>",
+	"license": "Unlicense",
+	"dependencies": {
+		"fs-extra": "^4.0.2",
+		"gonzales-pe": "^4.2.2",
+		"invariant": "^2.2.2",
+		"js-yaml": "^3.13.1",
+		"minimatch": "^3.0.4",
+		"unist-util-find": "^1.0.1",
+		"unist-util-inspect": "^4.1.1",
+		"unist-util-is": "^2.1.1",
+		"unist-util-map": "^1.0.3",
+		"unist-util-remove": "^1.0.0",
+		"unist-util-remove-position": "^1.1.1",
+		"unist-util-select": "^1.5.0",
+		"unist-util-visit": "^1.1.3",
+		"unist-util-visit-parents": "^1.1.1",
+		"yargs": "^14.0.0"
+	},
+	"devDependencies": {
+		"ava": "^1.4.1"
+	}
 }


### PR DESCRIPTION
1 mem vulnerability found in package-lock.json

Propose to upgrade yargs to version 14.0.0 or later to get rid of required dependency "os-locale" which requires  "mem" module with vulnerability.

Details:
In nodejs-mem before version 4.0.0 there is a memory leak due to old results not being removed from the cache despite reaching maxAge. Exploitation of this can lead to exhaustion of memory and subsequent denial of service.
