### PR TITLE
update-yargs-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "unist-util-select": "^1.5.0",
     "unist-util-visit": "^1.1.3",
     "unist-util-visit-parents": "^1.1.1",
-    "yargs": "^9.0.1"
+    "yargs": "^14.0.0"
   },
   "devDependencies": {
     "ava": "^1.4.1"


### PR DESCRIPTION
1 mem vulnerability found in package-lock.json

Propose to upgrade yargs to version 14.0.0 or later to get rid of required dependency "os-locale" which requires "mem" module with vulnerability.

Details:
In nodejs-mem before version 4.0.0 there is a memory leak due to old results not being removed from the cache despite reaching maxAge. Exploitation of this can lead to exhaustion of memory and subsequent denial of service.